### PR TITLE
fix(README): update `link-check` badge

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Thank you for your suggestions!
 
 ## Testing Changes
 
-The README.md may be tested using []`awesome-lint`][1]
+The README.md may be tested using [`awesome-lint`][1]
 
 ## Updating your PR
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--lint disable awesome-git-repo-age-->
 # Awesome Cooklang Recipes [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
 
-[![link-check](https://img.shields.io/github/workflow/status/cooklang/awesome-cooklang-recipes/link-check?label=link-check&logo=github&style=for-the-badge)](https://github.com/cooklang/awesome-cooklang-recipes/actions/workflows/link-check.yaml)
+[![link-check](https://img.shields.io/github/actions/workflow/status/cooklang/awesome-cooklang-recipes/link-check.yaml?style=for-the-badge&logo=github&label=link-check)](https://github.com/cooklang/awesome-cooklang-recipes/actions/workflows/link-check.yaml)
 
 <img src="https://cooklang.org/images/logo.svg" align="left" width="144px" height="144px"/>
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

The primary focus of this PR is to update the `link-check` badge, restoring its functionality. This fixes a breaking change introduced by the Shields team described in [https://github.com/badges/shields/issues/8671](https://github.com/badges/shields/issues/8671).

This PR also fixes a Markdown issue in the CONTRIBUTING file that prevented the `awesome-lint` URL from rendering properly.

**Benefits**

- The README will no longer show an invalid badge to users.
- The CONTRIBUTING file will now link to `awesome-lint` as expected.

**Possible drawbacks**

No known drawbacks.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- mitigates [https://github.com/badges/shields/issues/8671](https://github.com/badges/shields/issues/8671)

**Additional information**

To the maintainers - thanks for your work on cooklang! I really like your project.